### PR TITLE
feat: refactor config use into a shared context

### DIFF
--- a/nerdlets/session-timeline-nerdlet/SessionTimelineContainer.js
+++ b/nerdlets/session-timeline-nerdlet/SessionTimelineContainer.js
@@ -4,10 +4,10 @@ import startCase from 'lodash.startcase'
 import SearchBarContainer from '../../src/components/search-bar/SearchBarContainer'
 import SearchResults from '../../src/components/search-results/SearchResults'
 import TimelineContainer from '../../src/components/timeline/TimelineContainer'
-import config from '../../src/config/config'
 import { formatSinceAndCompare } from '../../src/components/utils/nrql-formatter'
+import { withConfigContext } from '../../src/context/ConfigContext'
 
-export default class SessionTimelineContainer extends React.PureComponent {
+class SessionTimelineContainer extends React.PureComponent {
   state = {
     filter: '',
     session: '',
@@ -30,6 +30,7 @@ export default class SessionTimelineContainer extends React.PureComponent {
     const {
       entity,
       launcherUrlState: { timeRange },
+      config,
     } = this.props
     const { filter, session, sessionDate } = this.state
     const { searchAttribute } = config
@@ -97,3 +98,5 @@ export default class SessionTimelineContainer extends React.PureComponent {
     )
   }
 }
+
+export default withConfigContext(SessionTimelineContainer)

--- a/nerdlets/session-timeline-nerdlet/index.js
+++ b/nerdlets/session-timeline-nerdlet/index.js
@@ -7,6 +7,7 @@ import {
   BlockText,
   Spinner,
 } from 'nr1'
+import { ConfigProvider } from '../../src/context/ConfigContext'
 import SessionTimelineContainer from './SessionTimelineContainer'
 
 export default class Wrapper extends React.Component {
@@ -33,11 +34,13 @@ export default class Wrapper extends React.Component {
                       data.entities[0].guid
                     ) {
                       return (
-                        <SessionTimelineContainer
-                          launcherUrlState={platformUrlState}
-                          nerdletUrlState={nerdletUrlState}
-                          entity={data.entities[0]}
-                        />
+                        <ConfigProvider>
+                          <SessionTimelineContainer
+                            launcherUrlState={platformUrlState}
+                            nerdletUrlState={nerdletUrlState}
+                            entity={data.entities[0]}
+                          />
+                        </ConfigProvider>
                       )
                     } else {
                       return (

--- a/src/components/search-bar/SearchBarContainer.js
+++ b/src/components/search-bar/SearchBarContainer.js
@@ -3,9 +3,9 @@ import PropTypes from 'prop-types'
 import startCase from 'lodash.startcase'
 import { TextField, NerdGraphQuery, Icon, HeadingText } from 'nr1'
 import SearchBarDrawer from './SearchBarDrawer'
-import config from '../../config/config'
+import { withConfigContext } from '../../context/ConfigContext'
 
-export default class SearchBarContainer extends React.Component {
+class SearchBarContainer extends React.Component {
   state = {
     loading: true,
     searchTerm: '',
@@ -15,8 +15,11 @@ export default class SearchBarContainer extends React.Component {
   }
 
   loadData = async searchTerm => {
-    const { entity, duration } = this.props
-    const { searchAttribute, groupingAttribute, event } = config
+    const {
+      entity,
+      duration,
+      config: { searchAttribute, groupingAttribute, event },
+    } = this.props
     const nrql = `FROM ${event} SELECT uniques(${searchAttribute}) WHERE entityGuid='${entity.guid}' AND ${searchAttribute} like '%${searchTerm}%' and ${groupingAttribute} is not null ${duration.since} `
 
     const query = `{
@@ -120,7 +123,9 @@ export default class SearchBarContainer extends React.Component {
 
   render() {
     const { loading, results, searchTerm, selectedItem } = this.state
-    const { searchAttribute } = config
+    const {
+      config: { searchAttribute },
+    } = this.props
 
     return (
       <div className="search">
@@ -176,3 +181,5 @@ SearchBarContainer.propTypes = {
   clearFilter: PropTypes.func.isRequired,
   duration: PropTypes.object.isRequired,
 }
+
+export default withConfigContext(SearchBarContainer)

--- a/src/components/search-results/SearchResults.js
+++ b/src/components/search-results/SearchResults.js
@@ -10,11 +10,13 @@ import {
   TableRowCell,
   HeadingText,
 } from 'nr1'
-import config from '../../config/config'
+import { withConfigContext } from '../../context/ConfigContext'
 
-export default class SearchResults extends React.Component {
+class SearchResults extends React.Component {
   flattenData = data => {
-    const { groupingAttribute } = config
+    const {
+      config: { groupingAttribute },
+    } = this.props
     let flattened = []
 
     for (let datum of data) {
@@ -74,8 +76,8 @@ export default class SearchResults extends React.Component {
       entity: { accountId },
       selected,
       duration,
+      config: { groupingAttribute, searchAttribute, event },
     } = this.props
-    const { groupingAttribute, searchAttribute, event } = config
     const query = `FROM ${event} SELECT uniques(${groupingAttribute}) WHERE ${searchAttribute}='${selected}' ${duration.since} FACET dateOf(timestamp) `
 
     return (
@@ -113,3 +115,5 @@ SearchResults.propTypes = {
   chooseSession: PropTypes.func.isRequired,
   duration: PropTypes.object.isRequired,
 }
+
+export default withConfigContext(SearchResults)

--- a/src/components/timeline/EventStream.js
+++ b/src/components/timeline/EventStream.js
@@ -2,9 +2,9 @@ import React from 'react'
 import { Spinner, Button, Icon, Stack, StackItem } from 'nr1'
 import Moment from 'react-moment'
 import startCase from 'lodash.startcase'
-import config from '../../config/config'
+import { withConfigContext } from '../../context/ConfigContext'
 
-export default class EventStream extends React.Component {
+class EventStream extends React.Component {
   state = {
     expandedTimelineItem: null,
   }
@@ -40,7 +40,9 @@ export default class EventStream extends React.Component {
   }
 
   getTitleDetails = event => {
-    const { eventTitleAttributes } = config
+    const {
+      config: { eventTitleAttributes },
+    } = this.props
     const { primary, secondary, truncateStart } = eventTitleAttributes.filter(
       attr => attr.name === event.eventType
     )[0]
@@ -75,8 +77,10 @@ export default class EventStream extends React.Component {
           {conditions.map((c, idx) => {
             return (
               <li key={idx} className="warning-condition">
-                {c.attribute} &gt; {c.threshold} 
-                <span className="warning-condition__actual-value ">[this event: {c.actual}]</span>
+                {c.attribute} &gt; {c.threshold}
+                <span className="warning-condition__actual-value ">
+                  [this event: {c.actual}]
+                </span>
               </li>
             )
           })}
@@ -201,3 +205,5 @@ export default class EventStream extends React.Component {
     )
   }
 }
+
+export default withConfigContext(EventStream)

--- a/src/components/timeline/TimelineContainer.js
+++ b/src/components/timeline/TimelineContainer.js
@@ -7,9 +7,9 @@ import cloneDeep from 'lodash.clonedeep'
 import EventStream from './EventStream'
 import Timeline from './Timeline'
 import eventGroup from './EventGroup'
-import config from '../../config/config'
+import { withConfigContext } from '../../context/ConfigContext'
 
-export default class TimelineContainer extends React.Component {
+class TimelineContainer extends React.Component {
   state = {
     sessionData: [],
     loading: true,
@@ -56,13 +56,8 @@ export default class TimelineContainer extends React.Component {
       session,
       sessionDate,
       duration,
+      config: { event, searchAttribute, groupingAttribute, linkingAttribute },
     } = this.props
-    const {
-      event,
-      searchAttribute,
-      groupingAttribute,
-      linkingAttribute,
-    } = config
 
     let attributeClause = `${groupingAttribute} = '${session}' and ${searchAttribute} = '${filter}'`
     if (linkingAttribute) {
@@ -89,7 +84,9 @@ export default class TimelineContainer extends React.Component {
   }
 
   getWarningConditions = (event, eventType) => {
-    const { eventThresholds } = config
+    const {
+      config: { eventThresholds },
+    } = this.props
     const thresholds = eventThresholds.filter(
       threshold => threshold.eventType === eventType
     )
@@ -187,7 +184,9 @@ export default class TimelineContainer extends React.Component {
     ) {
       this.setState({ loading: true })
 
-      const { timelineEventTypes } = config
+      const {
+        config: { timelineEventTypes },
+      } = this.props
       const linkingAttributeClause = await this.getLinkingClause()
       let data = []
       let warnings = false
@@ -228,8 +227,12 @@ export default class TimelineContainer extends React.Component {
       warningCount,
       showWarningsOnly,
     } = this.state
-    const { session, sessionDate, filter } = this.props
-    const { searchAttribute } = config
+    const {
+      session,
+      sessionDate,
+      filter,
+      config: { searchAttribute },
+    } = this.props
 
     return (
       <React.Fragment>
@@ -319,3 +322,5 @@ TimelineContainer.propTypes = {
   filter: PropTypes.string.isRequired,
   duration: PropTypes.object.isRequired,
 }
+
+export default withConfigContext(TimelineContainer)

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -1,5 +1,5 @@
 export default {
-  searchAttribute: 'userId', // the attribute to locate related events (will search for groupingAttribute) - mandatory
+  searchAttribute: 'email', // the attribute to locate related events (will search for groupingAttribute) - mandatory
   event: 'BrowserInteraction', // the root event to search against and build the event stream from - mandatory
   groupingAttribute: 'session', // the attribute to group events - mandatory
   linkingAttribute: '', // the attribute to use to identify related events - optional, will use groupingAttribute if not present

--- a/src/context/ConfigContext.js
+++ b/src/context/ConfigContext.js
@@ -1,0 +1,32 @@
+import React from 'react'
+import baseConfig from '../../src/config/config'
+
+const ConfigContext = React.createContext()
+
+export class ConfigProvider extends React.Component {
+  state = {
+    config: baseConfig,
+  }
+
+  render() {
+    const { children } = this.props
+    return (
+      <ConfigContext.Provider
+        value={{
+          ...this.state,
+        }}
+      >
+        {children}
+      </ConfigContext.Provider>
+    )
+  }
+}
+
+export const ConfigConsumer = ConfigContext.Consumer
+export default ConfigContext
+
+export const withConfigContext = WrappedComponent => props => (
+  <ConfigConsumer>
+    {({ config }) => <WrappedComponent config={config} {...props} />}
+  </ConfigConsumer>
+)


### PR DESCRIPTION
Remove imports of the config.js file, instead loading it and sharing it via the ConfigContext component.