### PR TITLE
feat: edit configuration in the UI

### DIFF
--- a/nerdlets/main-nerdlet/SessionTimelineContainer.js
+++ b/nerdlets/main-nerdlet/SessionTimelineContainer.js
@@ -50,13 +50,14 @@ class SessionTimelineContainer extends React.PureComponent {
       entity,
       timeRange,
       firstTime,
+      editMode,
       config,
       configLoading: loading,
     } = this.props
     const { filter } = this.state
 
     if (loading) return <Spinner />
-    if (!loading && firstTime) {
+    if (!loading && editMode) {
       return (
         <div className="main__container">
           <ConfigurationContainer />

--- a/src/components/configuration/ConfigurationContainer.js
+++ b/src/components/configuration/ConfigurationContainer.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { BlockText, Button } from 'nr1'
+import { BlockText, Button, Tooltip } from 'nr1'
 import SectionHeader from '../section-header/SectionHeader'
 import { withConfigContext } from '../../context/ConfigContext'
 import { schema } from '../../data/packSchema'
@@ -7,7 +7,13 @@ import { createComponent } from './ConfigFormComponentFactory'
 
 class ConfigurationContainer extends React.PureComponent {
   render() {
-    const { saveConfig, config } = this.props
+    const {
+      saveConfig,
+      config,
+      firstTime,
+      deleteConfig,
+      cancelEditConfig,
+    } = this.props
 
     const formContents = Object.entries(config).map(([key, value]) => {
       return createComponent(schema, key, value)
@@ -15,42 +21,57 @@ class ConfigurationContainer extends React.PureComponent {
 
     return (
       <div className="init-config__container">
-        <SectionHeader header="First Time Set Up" />
-        <BlockText
-          type={BlockText.TYPE.PARAGRAPH}
-          className="init-config__desc"
-        >
-          Please complete the form below to start using the User Session
-          Analysis app.
-        </BlockText>
+        {firstTime ? (
+          <>
+            <SectionHeader header="First Time Set Up" />
+            <BlockText
+              type={BlockText.TYPE.PARAGRAPH}
+              className="init-config__desc"
+            >
+              Please complete the form below to start using the User Session
+              Analysis app.
+            </BlockText>
 
-        <BlockText
-          type={BlockText.TYPE.PARAGRAPH}
-          className="init-config__desc"
-        >
-          We have provided some default values - at a minimun, make sure the
-          User Identifier matches the user attribute you are capturing in your
-          data.
-        </BlockText>
+            <BlockText
+              type={BlockText.TYPE.PARAGRAPH}
+              className="init-config__desc"
+            >
+              We have provided some default values - at a minimun, make sure the
+              User Identifier matches the user attribute you are capturing in
+              your data.
+            </BlockText>
 
-        <BlockText
-          type={BlockText.TYPE.PARAGRAPH}
-          className="init-config__desc"
-        >
-          When you are ready, click Continue. You will be able to change these
-          at any time in the app's configuration menu.
-        </BlockText>
-
+            <BlockText
+              type={BlockText.TYPE.PARAGRAPH}
+              className="init-config__desc"
+            >
+              When you are ready, click Continue. You will be able to change
+              these at any time in the app's configuration menu.
+            </BlockText>
+          </>
+        ) : (
+          <div className="config-form__header-edit">
+            <SectionHeader header="Edit Configuration" />
+            <Tooltip
+              placementType={Tooltip.PLACEMENT_TYPE.RIGHT}
+              text="Careful! This will delete your existing config and cannot be undone."
+            >
+              <Button type={Button.TYPE.DESTRUCTIVE} onClick={deleteConfig}>
+                Reset to Defaults
+              </Button>
+            </Tooltip>
+          </div>
+        )}
         <div className="config-form__container">{formContents}</div>
         <div className="button-row">
           <Button onClick={saveConfig} type={Button.TYPE.PRIMARY}>
-            Continue
+            {firstTime ? 'Continue' : 'Save'}
           </Button>
+          {!firstTime && <Button onClick={cancelEditConfig}>Cancel</Button>}
         </div>
       </div>
     )
   }
 }
 
-// export default ConfigurationContainer
 export default withConfigContext(ConfigurationContainer)

--- a/src/components/configuration/FormInput.js
+++ b/src/components/configuration/FormInput.js
@@ -3,7 +3,7 @@ import { TextField, Tooltip } from 'nr1'
 import { transformCamelCaseForDisplay } from '../../utils/text-formatter'
 import { withConfigContext } from '../../context/ConfigContext'
 
-const FormInput = ({ path, schemaItem, value, changeConfig }) => {
+const FormInput = ({ path, schemaItem, value, changeConfigItem }) => {
   return (
     <Tooltip
       placementType={Tooltip.PLACEMENT_TYPE.RIGHT}
@@ -11,7 +11,7 @@ const FormInput = ({ path, schemaItem, value, changeConfig }) => {
     >
       <TextField
         defaultValue={value}
-        onChange={e => changeConfig(path, e.target.value)}
+        onChange={e => changeConfigItem(path, e.target.value)}
         label={
           schemaItem.title
             ? schemaItem.title

--- a/src/components/configuration/FormSelect.js
+++ b/src/components/configuration/FormSelect.js
@@ -4,7 +4,13 @@ import { transformCamelCaseForDisplay } from '../../utils/text-formatter'
 import { withConfigContext } from '../../context/ConfigContext'
 import FormInput from './FormInput'
 
-const FormSelect = ({ path, schemaItem, value, lookupValue, changeConfig }) => {
+const FormSelect = ({
+  path,
+  schemaItem,
+  value,
+  lookupValue,
+  changeConfigItem,
+}) => {
   const selectItems = lookupValue(schemaItem.source)
   return (
     <Tooltip
@@ -14,7 +20,7 @@ const FormSelect = ({ path, schemaItem, value, lookupValue, changeConfig }) => {
       {selectItems ? (
         <Select
           value={value}
-          onChange={(event, value) => changeConfig(path, value)}
+          onChange={(event, value) => changeConfigItem(path, value)}
           label={
             schemaItem.title
               ? schemaItem.title

--- a/src/components/search-bar/SearchBarContainer.js
+++ b/src/components/search-bar/SearchBarContainer.js
@@ -128,18 +128,13 @@ class SearchBarContainer extends React.Component {
     })
   }
 
-  onConfigClick = () => {
-    console.info('config clicked!')
-  }
-
   render() {
     const { loading, results, searchTerm, selectedItem } = this.state
     const {
       config: { searchAttribute },
-      deleteConfig,
+      editConfig,
     } = this.props
 
-    console.info('searchBar props', this.props)
     return (
       <div className="search">
         <div className="search__bar">
@@ -185,10 +180,6 @@ class SearchBarContainer extends React.Component {
         )}
 
         <div className="button-row">
-          <Button type={Button.TYPE.NORMAL} onClick={deleteConfig}>
-            Delete Config
-          </Button>
-
           <Tooltip
             text="Change the app configuration"
             placementType={Tooltip.PLACEMENT_TYPE.BOTTOM}
@@ -196,7 +187,7 @@ class SearchBarContainer extends React.Component {
             <Button
               type={Button.TYPE.NORMAL}
               iconType={Button.ICON_TYPE.INTERFACE__OPERATIONS__CONFIGURE}
-              onClick={this.onConfigClick}
+              onClick={editConfig}
             />
           </Tooltip>
         </div>

--- a/src/context/ConfigContext.js
+++ b/src/context/ConfigContext.js
@@ -13,6 +13,7 @@ export class ConfigProvider extends React.Component {
     goldenMetricQueries: [],
     entity: undefined,
     firstTime: true,
+    editMode: false,
   }
 
   async componentDidMount() {
@@ -43,8 +44,10 @@ export class ConfigProvider extends React.Component {
       const entity = data?.entities?.[0]
       let config = await readDocument(entityGuid)
       let firstTime = false
+      let editMode = false
       if (!config) {
         firstTime = true
+        editMode = true
         config = this.defaultConfig(entity)
       }
 
@@ -54,6 +57,7 @@ export class ConfigProvider extends React.Component {
         config,
         configLoading: false,
         firstTime,
+        editMode,
       })
     }
   }
@@ -93,12 +97,23 @@ export class ConfigProvider extends React.Component {
     this.setState({ config })
   }
 
+  onEditConfig = () => {
+    this.setState({ editMode: true })
+  }
+
+  onCancelEditConfig = () => {
+    this.setState({ editMode: false })
+  }
+
   onSaveConfig = async () => {
     const { entity, config } = this.state
     await writeDocument(entity.guid, config)
-    this.setState({ config, configLoading: true, firstTime: false }, () => {
-      this.setState({ configLoading: false })
-    })
+    this.setState(
+      { config, configLoading: true, firstTime: false, editMode: false },
+      () => {
+        this.setState({ configLoading: false })
+      }
+    )
   }
 
   onDeleteConfig = async () => {
@@ -109,6 +124,7 @@ export class ConfigProvider extends React.Component {
         config: this.defaultConfig(entity),
         configLoading: true,
         firstTime: true,
+        editMode: true,
       },
       () => {
         this.setState({ configLoading: false })
@@ -122,9 +138,11 @@ export class ConfigProvider extends React.Component {
       <ConfigContext.Provider
         value={{
           ...this.state,
+          editConfig: this.onEditConfig,
+          cancelEditConfig: this.onCancelEditConfig,
           saveConfig: this.onSaveConfig,
           deleteConfig: this.onDeleteConfig,
-          changeConfig: this.onChangeConfigItem,
+          changeConfigItem: this.onChangeConfigItem,
           addConfigItem: this.onAddConfigItem,
           deleteConfigItem: this.onDeleteConfigItem,
           lookupValue: this.getConfigValue,
@@ -146,11 +164,14 @@ export const withConfigContext = WrappedComponent => props => {
         configLoading,
         config,
         firstTime,
+        editMode,
         goldenMetricQueries,
         entity,
+        editConfig,
+        cancelEditConfig,
         saveConfig,
         deleteConfig,
-        changeConfig,
+        changeConfigItem,
         addConfigItem,
         deleteConfigItem,
         lookupValue,
@@ -159,11 +180,14 @@ export const withConfigContext = WrappedComponent => props => {
           configLoading={configLoading}
           config={config}
           firstTime={firstTime}
+          editMode={editMode}
           goldenMetricQueries={goldenMetricQueries}
           entity={entity}
+          editConfig={editConfig}
+          cancelEditConfig={cancelEditConfig}
           saveConfig={saveConfig}
           deleteConfig={deleteConfig}
-          changeConfig={changeConfig}
+          changeConfigItem={changeConfigItem}
           addConfigItem={addConfigItem}
           deleteConfigItem={deleteConfigItem}
           lookupValue={lookupValue}

--- a/src/styles/common.scss
+++ b/src/styles/common.scss
@@ -1,5 +1,5 @@
 .section-header {
-  padding: 0.5rem 0.25rem 0 0.25rem;
+  padding: 0.5rem 0.25rem;
 }
 
 .section-subheader {

--- a/src/styles/configuration.scss
+++ b/src/styles/configuration.scss
@@ -16,6 +16,16 @@
   flex-direction: column;
 }
 
+.config-form__header-edit {
+  display: flex;
+  justify-content: space-between;
+  padding: 0.5rem 0;
+
+  & button {
+    max-height: 32px;
+  }
+}
+
 .config-form__item {
   display: inline-block;
   padding: 0.5rem;


### PR DESCRIPTION
Add support to allow the configuration to be edited from within the app.

Move delete functionality into the configuration form to allow the stored configuration to be deleted and reset to the pack defaults.

(renamed ConfigContext.onChangeConfig to onChangeConfigItem for clarity)

Closes issue-12